### PR TITLE
Updated AID, Use wallet:address to retrieve users address

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,9 +1,7 @@
 import dotenv from 'dotenv';
 dotenv.config();
 
-export const AID = 'F2222222222222'; // must match the AID in your Android app
-export const GET = Buffer.from('80CA000000', 'hex'); // "GET_STRING" APDU
-export const PAYMENT = Buffer.from('80CF000000', 'hex'); // "PAYMENT" APDU
+export const AID = 'F043525950544F'; // must match the AID in your Android app
 
 // Recipient address for payments (replace with your actual receiving address)
 export const RECIPIENT_ADDRESS = '0xaD66946538E4B03B1910DadE713feBb8B59Cff60';


### PR DESCRIPTION
- Updated AID to F043525950544F for both merchant-terminal and customer-android-app. This is F0 + CRYPTO from ASCII -> HEX.
- Instead of custom APDU commands send the NDEF string wallet:address to retrieve the users wallet address. This means other wallets can support this intent and return their address instead of doing something custom for the customer-android-app.