### PR TITLE
feat: Add testing infrastructure with mocked backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,96 @@
+# Dependencies
 node_modules/
+package-lock.json
+
+# Build outputs
 dist/
+build/
+
+# Environment files
 .env
+.env.local
+.env.*.local
+
+# Logs
 server.log
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage/
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# Dependency directories
+jspm_packages/
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Microbundle cache
+.rpt2_cache/
+.rts2_cache_cjs/
+.rts2_cache_es/
+.rts2_cache_umd/
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# parcel-bundler cache (https://parceljs.org/)
+.cache
+.parcel-cache
+
+# Next.js build output
+.next
+
+# Nuxt.js build / generate output
+.nuxt
+
+# Storybook build outputs
+.out
+.storybook-out
+
+# Temporary folders
+tmp/
+temp/
+
+# Editor directories and files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Project specific
 working-nfc-service.ts
 build-config.env
-build/
 *.img
 *.img.gz
-.DS_Store

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,39 @@
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+      tsconfig: {
+        noImplicitAny: false,
+        strict: false,
+        esModuleInterop: true,
+        allowSyntheticDefaultImports: true,
+      },
+    },
+  },
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src', '<rootDir>/tests'],
+  testMatch: [
+    '**/__tests__/**/*.ts',
+    '**/?(*.)+(spec|test).ts'
+  ],
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.d.ts',
+    '!src/server.ts', // Exclude server entry point from coverage
+  ],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov', 'html'],
+  setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
+  testTimeout: 10000,
+  // Mock external modules
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^nfc-pcsc$': '<rootDir>/tests/mocks/nfc-pcsc.mock.ts',
+    '^ws$': '<rootDir>/tests/mocks/ws.mock.ts',
+  },
+  // Clear mocks between tests
+  clearMocks: true,
+  restoreMocks: true,
+}; 

--- a/package.json
+++ b/package.json
@@ -9,19 +9,26 @@
     "prestart": "npm run clean && npm run build",
     "start:backend": "NODE_OPTIONS='--trace-warnings --trace-uncaught --trace-exit --trace-sigint --stack-trace-limit=100' node --loader ts-node/esm src/server.ts",
     "start": "concurrently \"npm run start:backend\" \"wait-on http://localhost:3000 && open http://localhost:3000\"",
-    "lint": "eslint . --ext .ts"
+    "lint": "eslint . --ext .ts",
+    "test": "node --experimental-vm-modules node_modules/.bin/jest",
+    "test:watch": "node --experimental-vm-modules node_modules/.bin/jest --watch",
+    "test:coverage": "node --experimental-vm-modules node_modules/.bin/jest --coverage"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "description": "",
   "devDependencies": {
+    "@jest/globals": "^29.7.0",
     "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
     "@types/ws": "^8.5.10",
     "concurrently": "^8.2.2",
     "eslint": "^8.57.0",
+    "jest": "^29.7.0",
     "nodemon": "^3.1.0",
+    "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5",
     "wait-on": "^7.2.0"

--- a/tests/basic.test.ts
+++ b/tests/basic.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Basic test to verify testing infrastructure is working
+ */
+
+import { jest } from '@jest/globals';
+
+describe('Testing Infrastructure', () => {
+  it('should have Jest working', () => {
+    expect(true).toBe(true);
+  });
+
+  it('should have test utilities available', () => {
+    expect(global.testUtils).toBeDefined();
+    expect(typeof global.testUtils.createMockResponse).toBe('function');
+    expect(typeof global.testUtils.createMockError).toBe('function');
+    expect(typeof global.testUtils.wait).toBe('function');
+  });
+
+  it('should have environment variables set', () => {
+    expect(process.env.NODE_ENV).toBe('test');
+    expect(process.env.ALCHEMY_API_KEY).toBe('test-alchemy-key');
+    expect(process.env.RECIPIENT_ADDRESS).toBe('0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6');
+  });
+
+  it('should be able to use test utilities', async () => {
+    const mockResponse = global.testUtils.createMockResponse({ data: 'test' });
+    expect(mockResponse.data).toEqual({ data: 'test' });
+    expect(mockResponse.status).toBe(200);
+
+    const mockError = global.testUtils.createMockError('test error');
+    expect(mockError.message).toBe('test error');
+    expect(mockError.status).toBe(500);
+
+    const startTime = Date.now();
+    await global.testUtils.wait(10);
+    const endTime = Date.now();
+    expect(endTime - startTime).toBeGreaterThanOrEqual(10);
+  });
+}); 

--- a/tests/mocks/nfc-pcsc.mock.ts
+++ b/tests/mocks/nfc-pcsc.mock.ts
@@ -1,0 +1,67 @@
+/**
+ * Mock for nfc-pcsc library
+ * Prevents real NFC hardware calls during testing
+ */
+
+export class Reader {
+  public name: string;
+  public connected: boolean = false;
+  public card: any = null;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  connect(): Promise<void> {
+    this.connected = true;
+    return Promise.resolve();
+  }
+
+  disconnect(): Promise<void> {
+    this.connected = false;
+    return Promise.resolve();
+  }
+
+  transmit(_data: Buffer, _maxLength: number): Promise<Buffer> {
+    // Mock NFC response - simulate wallet address
+    const mockResponse = Buffer.from([
+      0x90, 0x00, // Status OK
+      // Mock wallet address: 0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6
+      0x37, 0x34, 0x32, 0x64, 0x33, 0x35, 0x43, 0x63, 0x36, 0x36, 0x33, 0x34, 0x43, 0x30, 0x35, 0x33, 0x32, 0x39, 0x32, 0x35, 0x61, 0x33, 0x62, 0x38, 0x44, 0x34, 0x43, 0x39, 0x64, 0x62, 0x39, 0x36, 0x43, 0x34, 0x62, 0x34, 0x64, 0x38, 0x62, 0x36
+    ]);
+    return Promise.resolve(mockResponse);
+  }
+
+  on(event: string, callback: (...args: any[]) => void): void {
+    // Mock event handling
+    if (event === 'card') {
+      // Simulate card detection after a short delay
+      setTimeout(() => {
+        this.card = { uid: 'mock-card-uid' };
+        callback(this.card);
+      }, 100);
+    }
+  }
+
+  removeAllListeners(): void {
+    // Mock cleanup
+  }
+}
+
+export class Card {
+  public uid: string;
+
+  constructor(uid: string) {
+    this.uid = uid;
+  }
+
+  getUID(): string {
+    return this.uid;
+  }
+}
+
+// Mock the library exports
+export default {
+  Reader,
+  Card,
+}; 

--- a/tests/mocks/ws.mock.ts
+++ b/tests/mocks/ws.mock.ts
@@ -1,0 +1,81 @@
+/**
+ * Mock for WebSocket library
+ * Prevents real WebSocket connections during testing
+ */
+
+export class WebSocket {
+  public url: string;
+  public readyState: number = 0; // CONNECTING
+  public onopen: ((event: any) => void) | null = null;
+  public onmessage: ((event: any) => void) | null = null;
+  public onerror: ((event: any) => void) | null = null;
+  public onclose: ((event: any) => void) | null = null;
+  public send: (data: string | Buffer) => void;
+  public close: (code?: number, reason?: string) => void;
+
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  constructor(url: string) {
+    this.url = url;
+    
+    // Mock send method
+    this.send = jest.fn();
+    
+    // Mock close method
+    this.close = jest.fn((code = 1000, reason = '') => {
+      this.readyState = WebSocket.CLOSED;
+      if (this.onclose) {
+        this.onclose({ code, reason });
+      }
+    });
+
+    // Simulate connection after a short delay
+    setTimeout(() => {
+      this.readyState = WebSocket.OPEN;
+      if (this.onopen) {
+        this.onopen({});
+      }
+    }, 10);
+  }
+
+  // Mock event listener methods
+  addEventListener(event: string, listener: (...args: any[]) => void): void {
+    switch (event) {
+      case 'open':
+        this.onopen = listener;
+        break;
+      case 'message':
+        this.onmessage = listener;
+        break;
+      case 'error':
+        this.onerror = listener;
+        break;
+      case 'close':
+        this.onclose = listener;
+        break;
+    }
+  }
+
+  removeEventListener(_event: string, _listener: (...args: any[]) => void): void {
+    // Mock cleanup
+  }
+
+  // Mock message sending
+  mockMessage(data: any): void {
+    if (this.onmessage) {
+      this.onmessage({ data: JSON.stringify(data) });
+    }
+  }
+
+  // Mock error
+  mockError(error: any): void {
+    if (this.onerror) {
+      this.onerror(error);
+    }
+  }
+}
+
+export default WebSocket; 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,71 @@
+/**
+ * Test setup file for Jest
+ * Configures global mocks and test environment
+ */
+
+import { jest } from '@jest/globals';
+
+// Global test timeout
+jest.setTimeout(10000);
+
+// Mock environment variables for testing
+process.env.NODE_ENV = 'test';
+process.env.ALCHEMY_API_KEY = 'test-alchemy-key';
+process.env.RECIPIENT_ADDRESS = '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6';
+
+// Suppress console output during tests unless explicitly needed
+const originalConsoleLog = console.log;
+const originalConsoleError = console.error;
+const originalConsoleWarn = console.warn;
+
+beforeAll(() => {
+  // Only show console output for tests that explicitly need it
+  if (process.env.DEBUG_TESTS !== 'true') {
+    console.log = jest.fn();
+    console.error = jest.fn();
+    console.warn = jest.fn();
+  }
+});
+
+afterAll(() => {
+  // Restore console functions
+  console.log = originalConsoleLog;
+  console.error = originalConsoleError;
+  console.warn = originalConsoleWarn;
+});
+
+// Global test utilities
+global.testUtils = {
+  // Mock response helpers
+  createMockResponse: (data: any, status: number = 200) => ({
+    data,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    headers: {},
+    config: {},
+  }),
+
+  // Mock error helpers
+  createMockError: (message: string, status: number = 500) => ({
+    message,
+    status,
+    response: {
+      data: { error: message },
+      status,
+      statusText: 'Error',
+    },
+  }),
+
+  // Wait helper for async operations
+  wait: (ms: number) => new Promise(resolve => setTimeout(resolve, ms)),
+};
+
+// Type declarations for global test utilities
+declare global {
+  // eslint-disable-next-line no-var
+  var testUtils: {
+    createMockResponse: (data: any, status?: number) => any;
+    createMockError: (message: string, status?: number) => any;
+    wait: (ms: number) => Promise<void>;
+  };
+} 

--- a/tests/utils/testHelpers.ts
+++ b/tests/utils/testHelpers.ts
@@ -1,0 +1,115 @@
+/**
+ * Test utility functions for common testing scenarios
+ */
+
+import { jest } from '@jest/globals';
+
+/**
+ * Mock Alchemy SDK responses
+ */
+export const mockAlchemyResponses = {
+  // Mock balance response
+  balance: {
+    result: '0x1000000000000000000', // 1 ETH in wei
+    jsonrpc: '2.0',
+    id: 1
+  },
+
+  // Mock token balances response
+  tokenBalances: {
+    result: {
+      address: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
+      tokenBalances: [
+        {
+          contractAddress: '0xA0b86a33E6441b8c4C8C8C8C8C8C8C8C8C8C8C8C',
+          tokenBalance: '0x100000000000000000',
+          error: null
+        }
+      ]
+    },
+    jsonrpc: '2.0',
+    id: 1
+  },
+
+  // Mock transaction monitoring response
+  pendingTransaction: {
+    result: {
+      hash: '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+      to: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
+      value: '0x100000000000000000',
+      input: '0x',
+      blockNumber: null
+    },
+    jsonrpc: '2.0',
+    id: 1
+  }
+};
+
+
+
+/**
+ * Create a mock HTTP response
+ */
+export const createMockHttpResponse = (data: any, status: number = 200) => ({
+  data,
+  status,
+  statusText: status === 200 ? 'OK' : 'Error',
+  headers: {},
+  config: {},
+});
+
+/**
+ * Create a mock HTTP error
+ */
+export const createMockHttpError = (message: string, status: number = 500) => ({
+  message,
+  status,
+  response: {
+    data: { error: message },
+    status,
+    statusText: 'Error',
+  },
+});
+
+/**
+ * Wait for a specified number of milliseconds
+ */
+export const wait = (ms: number): Promise<void> => 
+  new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * Mock environment variables for testing
+ */
+export const mockEnvVars = {
+  ALCHEMY_API_KEY: 'test-alchemy-key',
+  RECIPIENT_ADDRESS: '0x742d35Cc6634C0532925a3b8D4C9db96C4b4d8b6',
+  NODE_ENV: 'test',
+};
+
+/**
+ * Setup test environment
+ */
+export const setupTestEnv = () => {
+  // Set environment variables
+  Object.entries(mockEnvVars).forEach(([key, value]) => {
+    process.env[key] = value;
+  });
+
+  // Mock console methods to reduce noise
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+};
+
+/**
+ * Cleanup test environment
+ */
+export const cleanupTestEnv = () => {
+  // Restore console methods
+  jest.restoreAllMocks();
+  
+  // Clear environment variables
+  Object.keys(mockEnvVars).forEach(key => {
+    delete process.env[key];
+  });
+}; 


### PR DESCRIPTION
feat: Add testing infrastructure with mocked backends

- Add Jest config with ESM support and module mapping
- Create test setup with environment config and utilities  
- Add mocks for nfc-pcsc and WebSocket libraries
- Add test utilities for common scenarios
- Add working basic tests with mocked infrastructure
- Configure TypeScript support for Jest
- Set up test environment variables and console mocking
- Add comprehensive .gitignore with proper exclusions

Provides foundation for testing without API keys or hardware, 
enabling proper CI/CD testing in GitHub Actions.