### PR TITLE
Add support for bridging to the correct chain/token

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -12,6 +12,10 @@ if (!process.env.ALCHEMY_API_KEY) {
   throw new Error('ALCHEMY_API_KEY environment variable is required. Please set it in your .env file.');
 }
 
+if (!process.env.LAYERSWAP_API_KEY) {
+  throw new Error('LAYERSWAP_API_KEY environment variable is required. Please set it in your .env file.');
+}
+
 // Recipient address for payments - loaded from environment variable
 export const MERCHANT_ADDRESS = process.env.MERCHANT_ADDRESS;
 
@@ -21,6 +25,15 @@ export const COOLDOWN_DURATION = 30000; // 30 seconds cooldown after processing
 
 // API configuration
 export const ALCHEMY_API_KEY = process.env.ALCHEMY_API_KEY;
+export const LAYERSWAP_API_KEY = process.env.LAYERSWAP_API_KEY;
+
+// Parse merchant chains from environment variable
+// If not set, merchant accepts all chains
+export const MERCHANT_CHAINS = process.env.MERCHANT_CHAINS
+  ? process.env.MERCHANT_CHAINS
+      .split(',')
+      .map(chain => chain.trim().toLowerCase())
+  : null; // null means accept all chains
 
 // Multi-chain Alchemy configuration
 export interface ChainConfig {

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { App } from './app.js'; // App class will be refactored
 import { AlchemyService } from './services/alchemyService.js';
-import { SUPPORTED_CHAINS, ChainConfig } from './config/index.js';
+import { SUPPORTED_CHAINS, ChainConfig, MERCHANT_ADDRESS } from './config/index.js';
 import { TransactionMonitoringService } from './services/transactionMonitoringService.js';
 import { RealtimeTransactionMonitor } from './services/realtimeTransactionMonitor.js';
 import { ConnectionMonitorService } from './services/connectionMonitorService.js';
@@ -332,7 +332,9 @@ async function monitorTransaction(
 }
 
 const initiatePaymentHandler: AsyncRequestHandler = async (req, res) => {
-    const { amount, merchantAddress } = req.body;
+    const { amount } = req.body;
+    const merchantAddress = MERCHANT_ADDRESS;
+    
     if (typeof amount !== 'number' || amount <= 0 || isNaN(amount)) {
         broadcast({ type: 'status', message: 'Invalid amount received from UI.', isError: true });
         res.status(400).json({ error: 'Invalid amount' });

--- a/src/server.ts
+++ b/src/server.ts
@@ -358,84 +358,58 @@ const initiatePaymentHandler: AsyncRequestHandler = async (req, res) => {
             console.log(`✅ Payment request sent successfully: ${paymentResult.message}`);
             console.log(`⛓️ Payment sent on: ${paymentResult.paymentInfo.chainName} (Chain ID: ${paymentResult.paymentInfo.chainId})`);
             
-            // Check if this is a Layerswap payment
+            // Determine the target address based on whether it's a Layerswap transaction
+            const targetAddress = paymentResult.paymentInfo.isLayerswap 
+                ? paymentResult.paymentInfo.layerswapDepositAddress! 
+                : merchantAddress;
+            
             if (paymentResult.paymentInfo.isLayerswap) {
                 console.log(`💱 This is a Layerswap payment`);
                 console.log(`🔄 Swap ID: ${paymentResult.paymentInfo.layerswapSwapId}`);
                 console.log(`📍 Monitoring Layerswap deposit address: ${paymentResult.paymentInfo.layerswapDepositAddress}`);
+            }
+            
+            // Monitor the transaction with the appropriate target address
+            try {
+                await monitorTransaction(
+                    targetAddress, 
+                    amount, 
+                    paymentResult.paymentInfo.chainId, 
+                    paymentResult.paymentInfo.chainName,
+                    {
+                        tokenSymbol: paymentResult.paymentInfo.selectedToken.symbol,
+                        tokenAddress: paymentResult.paymentInfo.selectedToken.address,
+                        requiredAmount: paymentResult.paymentInfo.requiredAmount,
+                        decimals: paymentResult.paymentInfo.selectedToken.decimals
+                    }
+                );
+                console.log(`🔍 Monitoring started for ${paymentResult.paymentInfo.chainName} payment of exactly ${paymentResult.paymentInfo.requiredAmount} smallest units of ${paymentResult.paymentInfo.selectedToken.symbol}`);
+                broadcast({ 
+                    type: 'monitoring_started', 
+                    message: `Monitoring ${paymentResult.paymentInfo.chainName} for payment...`,
+                    chainName: paymentResult.paymentInfo.chainName,
+                    chainId: paymentResult.paymentInfo.chainId,
+                    isLayerswap: paymentResult.paymentInfo.isLayerswap
+                });
+            } catch (monitoringError) {
+                console.error(`❌ Failed to start monitoring on ${paymentResult.paymentInfo.chainName}:`, monitoringError);
                 
-                // For Layerswap, monitor the deposit address instead of merchant address
+                // Fallback: try to monitor on Ethereum mainnet (without specific token requirements)
+                console.log(`🔄 Falling back to Ethereum mainnet monitoring...`);
                 try {
-                    await monitorTransaction(
-                        paymentResult.paymentInfo.layerswapDepositAddress!, 
-                        amount, 
-                        paymentResult.paymentInfo.chainId, 
-                        paymentResult.paymentInfo.chainName,
-                        {
-                            tokenSymbol: paymentResult.paymentInfo.selectedToken.symbol,
-                            tokenAddress: paymentResult.paymentInfo.selectedToken.address,
-                            requiredAmount: paymentResult.paymentInfo.requiredAmount,
-                            decimals: paymentResult.paymentInfo.selectedToken.decimals
-                        }
-                    );
-                    console.log(`🔍 Monitoring started for Layerswap payment to ${paymentResult.paymentInfo.layerswapDepositAddress}`);
+                    await monitorTransaction(merchantAddress, amount, 1, "Ethereum (fallback)");
                     broadcast({ 
-                        type: 'monitoring_started', 
-                        message: `Monitoring ${paymentResult.paymentInfo.chainName} for Layerswap payment...`,
-                        chainName: paymentResult.paymentInfo.chainName,
-                        chainId: paymentResult.paymentInfo.chainId,
-                        isLayerswap: true
+                        type: 'status', 
+                        message: `Payment sent on ${paymentResult.paymentInfo.chainName}. Monitoring Ethereum mainnet as fallback.`,
+                        isWarning: true
                     });
-                } catch (monitoringError) {
-                    console.error(`❌ Failed to start monitoring for Layerswap payment:`, monitoringError);
+                } catch (fallbackError) {
+                    console.error(`❌ Fallback monitoring also failed:`, fallbackError);
                     broadcast({ 
                         type: 'payment_failure', 
-                        message: 'Layerswap payment sent but monitoring failed. Check swap status manually.', 
+                        message: 'Payment sent but monitoring failed. Please verify manually.', 
                         errorType: 'MONITORING_ERROR' 
                     });
-                }
-            } else {
-                // Normal payment monitoring (direct to merchant)
-                try {
-                    await monitorTransaction(
-                        merchantAddress, 
-                        amount, 
-                        paymentResult.paymentInfo.chainId, 
-                        paymentResult.paymentInfo.chainName,
-                        {
-                            tokenSymbol: paymentResult.paymentInfo.selectedToken.symbol,
-                            tokenAddress: paymentResult.paymentInfo.selectedToken.address,
-                            requiredAmount: paymentResult.paymentInfo.requiredAmount,
-                            decimals: paymentResult.paymentInfo.selectedToken.decimals
-                        }
-                    );
-                    console.log(`🔍 Monitoring started for ${paymentResult.paymentInfo.chainName} payment of exactly ${paymentResult.paymentInfo.requiredAmount} smallest units of ${paymentResult.paymentInfo.selectedToken.symbol}`);
-                    broadcast({ 
-                        type: 'monitoring_started', 
-                        message: `Monitoring ${paymentResult.paymentInfo.chainName} for payment...`,
-                        chainName: paymentResult.paymentInfo.chainName,
-                        chainId: paymentResult.paymentInfo.chainId
-                    });
-                } catch (monitoringError) {
-                    console.error(`❌ Failed to start monitoring on ${paymentResult.paymentInfo.chainName}:`, monitoringError);
-                    
-                    // Fallback: try to monitor on Ethereum mainnet (without specific token requirements)
-                    console.log(`🔄 Falling back to Ethereum mainnet monitoring...`);
-                    try {
-                        await monitorTransaction(merchantAddress, amount, 1, "Ethereum (fallback)");
-                        broadcast({ 
-                            type: 'status', 
-                            message: `Payment sent on ${paymentResult.paymentInfo.chainName}. Monitoring Ethereum mainnet as fallback.`,
-                            isWarning: true
-                        });
-                    } catch (fallbackError) {
-                        console.error(`❌ Fallback monitoring also failed:`, fallbackError);
-                        broadcast({ 
-                            type: 'payment_failure', 
-                            message: 'Payment sent but monitoring failed. Please verify manually.', 
-                            errorType: 'MONITORING_ERROR' 
-                        });
-                    }
                 }
             }
             

--- a/src/server.ts
+++ b/src/server.ts
@@ -159,6 +159,7 @@ async function monitorTransaction(
             try {
                 console.log(`🚀 Starting real-time WebSocket monitoring for ${chainName}`);
                 await RealtimeTransactionMonitor.startMonitoring(
+                    merchantAddress,  // Pass the recipient address (could be merchant or bridge)
                     expectedPayment.tokenAddress,
                     expectedPayment.requiredAmount,
                     expectedPayment.tokenSymbol,
@@ -237,6 +238,7 @@ async function monitorTransaction(
                 
                 // Fallback to original polling-based monitoring
                 await TransactionMonitoringService.startMonitoring(
+                    merchantAddress,  // Pass the recipient address (could be merchant or bridge)
                     expectedPayment.tokenAddress,
                     expectedPayment.requiredAmount,
                     expectedPayment.tokenSymbol,

--- a/src/services/bridgeManager.ts
+++ b/src/services/bridgeManager.ts
@@ -1,0 +1,132 @@
+import { BridgeProvider, BridgeRoute, BridgeSwapResult } from '../types/bridge.js';
+import { LayerswapBridgeProvider } from './bridges/layerswapBridgeProvider.js';
+
+/**
+ * Manages multiple bridge providers for cross-chain payments
+ */
+export class BridgeManager {
+  private static providers: BridgeProvider[] = [];
+  private static initialized = false;
+
+  /**
+   * Initialize all bridge providers
+   */
+  static async initialize(): Promise<void> {
+    if (this.initialized) {
+      return;
+    }
+
+    console.log('🌉 Initializing bridge providers...');
+
+    // Add Layerswap as the first provider
+    const layerswap = new LayerswapBridgeProvider();
+    
+    try {
+      await layerswap.initialize();
+      this.providers.push(layerswap);
+      console.log(`✅ Initialized ${layerswap.name} bridge provider`);
+    } catch (error) {
+      console.error(`⚠️ Failed to initialize ${layerswap.name}:`, error);
+    }
+
+    // Future bridge providers can be added here
+    // Example:
+    // const acrossBridge = new AcrossBridgeProvider();
+    // try {
+    //   await acrossBridge.initialize();
+    //   this.providers.push(acrossBridge);
+    // } catch (error) {
+    //   console.error(`Failed to initialize ${acrossBridge.name}:`, error);
+    // }
+
+    this.initialized = true;
+    console.log(`🌉 Bridge manager initialized with ${this.providers.length} provider(s)`);
+  }
+
+  /**
+   * Check if a chain is supported by the merchant (across all providers)
+   */
+  static isMerchantSupportedChain(chainId: number): boolean {
+    // If any provider says the chain is supported, it's supported
+    return this.providers.some(provider => provider.isMerchantSupportedChain(chainId));
+  }
+
+  /**
+   * Find the best route across all bridge providers
+   */
+  static async findBestRoute(sourceChainId: number, tokenSymbol: string): Promise<{
+    provider: BridgeProvider;
+    route: BridgeRoute;
+  } | null> {
+    console.log(`🔍 Searching for bridge routes from chain ${sourceChainId} for ${tokenSymbol}...`);
+
+    // Check all providers in parallel
+    const routePromises = this.providers.map(async (provider) => {
+      try {
+        const route = await provider.checkRoute(sourceChainId, tokenSymbol);
+        return { provider, route };
+      } catch (error) {
+        console.error(`Error checking route with ${provider.name}:`, error);
+        return { provider, route: null };
+      }
+    });
+
+    const results = await Promise.all(routePromises);
+
+    // Filter out null routes and find the best one
+    const validRoutes = results.filter(result => result.route && result.route.hasRoute);
+
+    if (validRoutes.length === 0) {
+      console.log('❌ No bridge routes found');
+      return null;
+    }
+
+    // For now, just return the first valid route
+    // In the future, we could compare fees, speed, etc.
+    const bestRoute = validRoutes[0];
+    console.log(`✅ Found route via ${bestRoute.provider.name} to ${bestRoute.route!.destinationNetwork}`);
+    
+    return {
+      provider: bestRoute.provider,
+      route: bestRoute.route!
+    };
+  }
+
+  /**
+   * Create a swap using the specified provider
+   */
+  static async createSwap(
+    provider: BridgeProvider,
+    route: BridgeRoute,
+    amount: number
+  ): Promise<BridgeSwapResult | null> {
+    try {
+      console.log(`💱 Creating swap via ${provider.name}...`);
+      const result = await provider.createSwap(route, amount);
+      
+      if (result) {
+        console.log(`✅ Swap created successfully via ${provider.name}`);
+        console.log(`🔄 Swap ID: ${result.swapId}`);
+      }
+      
+      return result;
+    } catch (error) {
+      console.error(`❌ Failed to create swap with ${provider.name}:`, error);
+      return null;
+    }
+  }
+
+  /**
+   * Get all available providers
+   */
+  static getProviders(): BridgeProvider[] {
+    return [...this.providers];
+  }
+
+  /**
+   * Check if any providers are available
+   */
+  static hasProviders(): boolean {
+    return this.providers.length > 0;
+  }
+}

--- a/src/services/bridges/layerswapBridgeProvider.ts
+++ b/src/services/bridges/layerswapBridgeProvider.ts
@@ -1,0 +1,52 @@
+import { BridgeProvider, BridgeRoute, BridgeSwapResult } from '../../types/bridge.js';
+import { LayerswapService } from '../layerswapService.js';
+
+/**
+ * Layerswap implementation of the BridgeProvider interface
+ */
+export class LayerswapBridgeProvider implements BridgeProvider {
+  name = 'Layerswap';
+
+  async initialize(): Promise<void> {
+    await LayerswapService.initialize();
+  }
+
+  isMerchantSupportedChain(chainId: number): boolean {
+    return LayerswapService.isMerchantSupportedChain(chainId);
+  }
+
+  async checkRoute(sourceChainId: number, tokenSymbol: string): Promise<BridgeRoute | null> {
+    const result = await LayerswapService.checkRoute(sourceChainId, tokenSymbol);
+    
+    if (!result.hasRoute || !result.destinationChainId || !result.destinationNetwork) {
+      return null;
+    }
+
+    return {
+      hasRoute: true,
+      bridgeName: this.name,
+      sourceChainId,
+      destinationChainId: result.destinationChainId,
+      destinationNetwork: result.destinationNetwork,
+      tokenSymbol
+    };
+  }
+
+  async createSwap(route: BridgeRoute, amount: number): Promise<BridgeSwapResult | null> {
+    const result = await LayerswapService.createSwap(
+      route.sourceChainId,
+      route.destinationChainId,
+      route.tokenSymbol,
+      amount
+    );
+
+    if (!result) {
+      return null;
+    }
+
+    return {
+      ...result,
+      bridgeName: this.name
+    };
+  }
+}

--- a/src/services/layerswapService.ts
+++ b/src/services/layerswapService.ts
@@ -1,0 +1,382 @@
+import https from 'https';
+import { LAYERSWAP_API_KEY, MERCHANT_ADDRESS, MERCHANT_CHAINS, SUPPORTED_CHAINS } from '../config/index.js';
+
+interface LayerswapNetwork {
+  name: string;
+  display_name: string;
+  chain_id: string;
+  tokens: LayerswapToken[];
+}
+
+interface LayerswapToken {
+  symbol: string;
+  contract: string | null;
+  decimals: number;
+}
+
+interface LayerswapQuote {
+  source_network: string;
+  destination_network: string;
+  source_token: string;
+  destination_token: string;
+  receive_amount: number;
+  total_fee_in_usd: number;
+}
+
+interface LayerswapSwap {
+  id: string;
+  destination_address: string;
+  status: string;
+  requested_amount: number;
+}
+
+interface LayerswapDepositAction {
+  to_address: string;
+  amount: number;
+  call_data: string;
+  token: LayerswapToken;
+  network: LayerswapNetwork;
+}
+
+export class LayerswapService {
+  private static supportedNetworks: LayerswapNetwork[] | null = null;
+  private static merchantNetworkNames: string[] = [];
+  
+  /**
+   * Initialize the service by fetching supported networks and validating merchant chains
+   */
+  static async initialize(): Promise<void> {
+    console.log('🔄 Initializing Layerswap service...');
+    
+    try {
+      // Fetch supported networks from Layerswap
+      await this.fetchSupportedNetworks();
+      
+      // Map merchant chain names to Layerswap network names
+      this.merchantNetworkNames = await this.mapMerchantChainsToLayerswap();
+      
+      console.log('✅ Layerswap service initialized');
+      console.log(`📍 Merchant accepts payments on: ${this.merchantNetworkNames.join(', ')}`);
+    } catch (error) {
+      console.error('❌ Failed to initialize Layerswap service:', error);
+      throw error;
+    }
+  }
+  
+  /**
+   * Fetch supported networks from Layerswap V2 API
+   */
+  private static async fetchSupportedNetworks(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const options = {
+        hostname: 'api.layerswap.io',
+        port: 443,
+        path: '/api/v2/networks',
+        method: 'GET',
+        headers: {
+          'X-LS-APIKEY': LAYERSWAP_API_KEY,
+          'Content-Type': 'application/json'
+        }
+      };
+      
+      const req = https.request(options, (res) => {
+        let data = '';
+        res.on('data', (chunk) => data += chunk);
+        res.on('end', () => {
+          if (res.statusCode === 200) {
+            try {
+              const response = JSON.parse(data);
+              this.supportedNetworks = response.data || response;
+              console.log(`✅ Fetched ${this.supportedNetworks!.length} networks from Layerswap`);
+              resolve();
+            } catch (e) {
+              reject(new Error('Failed to parse Layerswap networks response'));
+            }
+          } else {
+            reject(new Error(`Failed to fetch networks: ${res.statusCode}`));
+          }
+        });
+      });
+      
+      req.on('error', reject);
+      req.end();
+    });
+  }
+  
+  /**
+   * Map merchant chain names to Layerswap network names
+   */
+  private static async mapMerchantChainsToLayerswap(): Promise<string[]> {
+    if (!this.supportedNetworks) {
+      throw new Error('Networks not loaded');
+    }
+    
+    // If MERCHANT_CHAINS is null, merchant accepts all chains
+    if (!MERCHANT_CHAINS) {
+      // Return all networks that we support in our app
+      const allNetworks = this.supportedNetworks
+        .filter(network => {
+          // Only include networks that are in our SUPPORTED_CHAINS
+          const chainId = parseInt(network.chain_id);
+          return SUPPORTED_CHAINS.some(chain => chain.id === chainId);
+        })
+        .map(network => network.name);
+      
+      console.log(`✅ Merchant accepts all chains. Available networks: ${allNetworks.join(', ')}`);
+      return allNetworks;
+    }
+    
+    const mappedNetworks: string[] = [];
+    const unmappedChains: string[] = [];
+    
+    for (const merchantChain of MERCHANT_CHAINS) {
+      // Find matching network in Layerswap
+      const layerswapNetwork = this.supportedNetworks.find(network => {
+        const networkNameLower = network.name.toLowerCase();
+        const displayNameLower = network.display_name.toLowerCase();
+        
+        // Check if merchant chain matches network name or display name
+        return networkNameLower.includes(merchantChain) || 
+               displayNameLower === merchantChain ||
+               (merchantChain === 'arbitrum' && networkNameLower === 'arbitrum_mainnet') ||
+               (merchantChain === 'optimism' && networkNameLower === 'optimism_mainnet') ||
+               (merchantChain === 'base' && networkNameLower === 'base_mainnet') ||
+               (merchantChain === 'polygon' && networkNameLower === 'polygon_mainnet');
+      });
+      
+      if (layerswapNetwork) {
+        mappedNetworks.push(layerswapNetwork.name);
+        console.log(`✅ Mapped merchant chain '${merchantChain}' to Layerswap network '${layerswapNetwork.name}'`);
+      } else {
+        unmappedChains.push(merchantChain);
+      }
+    }
+    
+    if (unmappedChains.length > 0) {
+      throw new Error(`The following merchant chains are not supported by Layerswap: ${unmappedChains.join(', ')}`);
+    }
+    
+    return mappedNetworks;
+  }
+  
+  /**
+   * Check if a chain is supported by the merchant
+   */
+  static isMerchantSupportedChain(chainId: number): boolean {
+    // If MERCHANT_CHAINS is null, merchant accepts all chains
+    if (!MERCHANT_CHAINS) return true;
+    
+    const chain = SUPPORTED_CHAINS.find(c => c.id === chainId);
+    if (!chain) return false;
+    
+    // Check if this chain name is in merchant chains
+    return MERCHANT_CHAINS.includes(chain.name.toLowerCase());
+  }
+  
+  /**
+   * Get Layerswap network name for a chain ID
+   */
+  static getLayerswapNetworkName(chainId: number): string | null {
+    if (!this.supportedNetworks) return null;
+    
+    const chain = SUPPORTED_CHAINS.find(c => c.id === chainId);
+    if (!chain) return null;
+    
+    const network = this.supportedNetworks.find(n => 
+      n.chain_id === chainId.toString()
+    );
+    
+    return network?.name || null;
+  }
+  
+  /**
+   * Check if there's a route from source chain to any merchant chain for a token
+   */
+  static async checkRoute(sourceChainId: number, tokenSymbol: string): Promise<{
+    hasRoute: boolean;
+    destinationNetwork?: string;
+    destinationChainId?: number;
+  }> {
+    const sourceNetwork = this.getLayerswapNetworkName(sourceChainId);
+    if (!sourceNetwork) {
+      return { hasRoute: false };
+    }
+    
+    // Check routes to each merchant network
+    for (const merchantNetwork of this.merchantNetworkNames) {
+      try {
+        const quote = await this.getQuote(
+          sourceNetwork,
+          merchantNetwork,
+          tokenSymbol,
+          tokenSymbol,
+          1 // Test with 1 unit
+        );
+        
+        if (quote) {
+          // Find the chain ID for this merchant network
+          const network = this.supportedNetworks?.find(n => n.name === merchantNetwork);
+          const chainId = network ? parseInt(network.chain_id) : undefined;
+          
+          return { 
+            hasRoute: true, 
+            destinationNetwork: merchantNetwork,
+            destinationChainId: chainId
+          };
+        }
+      } catch (e) {
+        // Continue checking other merchant networks
+        continue;
+      }
+    }
+    
+    return { hasRoute: false };
+  }
+  
+  /**
+   * Get a quote from Layerswap
+   */
+  private static async getQuote(
+    sourceNetwork: string,
+    destinationNetwork: string,
+    sourceToken: string,
+    destinationToken: string,
+    amount: number
+  ): Promise<LayerswapQuote | null> {
+    return new Promise((resolve) => {
+      const queryParams = new URLSearchParams({
+        source_network: sourceNetwork,
+        destination_network: destinationNetwork,
+        source_token: sourceToken,
+        destination_token: destinationToken,
+        amount: amount.toString(),
+        refuel: 'false',
+        use_deposit_address: 'true'
+      });
+      
+      const options = {
+        hostname: 'api.layerswap.io',
+        port: 443,
+        path: `/api/v2/quote?${queryParams}`,
+        method: 'GET',
+        headers: {
+          'X-LS-APIKEY': LAYERSWAP_API_KEY,
+          'Content-Type': 'application/json'
+        }
+      };
+      
+      const req = https.request(options, (res) => {
+        let data = '';
+        res.on('data', (chunk) => data += chunk);
+        res.on('end', () => {
+          if (res.statusCode === 200 && data) {
+            try {
+              const quote = JSON.parse(data);
+              resolve(quote);
+            } catch (e) {
+              resolve(null);
+            }
+          } else {
+            resolve(null);
+          }
+        });
+      });
+      
+      req.on('error', () => resolve(null));
+      req.end();
+    });
+  }
+  
+  /**
+   * Create a swap on Layerswap
+   */
+  static async createSwap(
+    sourceChainId: number,
+    destinationChainId: number,
+    tokenSymbol: string,
+    amount: number
+  ): Promise<{
+    swapId: string;
+    depositAddress: string;
+    depositAmount: number;
+    callData: string;
+    tokenContract: string;
+  } | null> {
+    const sourceNetwork = this.getLayerswapNetworkName(sourceChainId);
+    const destinationNetwork = this.getLayerswapNetworkName(destinationChainId);
+    
+    if (!sourceNetwork || !destinationNetwork) {
+      console.error('Failed to map chain IDs to Layerswap networks');
+      return null;
+    }
+    
+    return new Promise((resolve) => {
+      const swapData = {
+        source_network: sourceNetwork,
+        destination_network: destinationNetwork,
+        source_token: tokenSymbol,
+        destination_token: tokenSymbol,
+        destination_address: MERCHANT_ADDRESS,
+        amount: amount,
+        refuel: false,
+        use_deposit_address: true,
+        reference_id: Date.now().toString()
+      };
+      
+      const options = {
+        hostname: 'api.layerswap.io',
+        port: 443,
+        path: '/api/v2/swaps',
+        method: 'POST',
+        headers: {
+          'X-LS-APIKEY': LAYERSWAP_API_KEY,
+          'Content-Type': 'application/json'
+        }
+      };
+      
+      const req = https.request(options, (res) => {
+        let data = '';
+        res.on('data', (chunk) => data += chunk);
+        res.on('end', () => {
+          if (res.statusCode === 200 || res.statusCode === 201) {
+            try {
+              const response = JSON.parse(data);
+              const swap = response.data.swap;
+              const depositAction = response.data.deposit_actions[0];
+              
+              if (depositAction && depositAction.call_data) {
+                // Decode the calldata to get the deposit address
+                const toAddress = '0x' + depositAction.call_data.slice(34, 74);
+                
+                resolve({
+                  swapId: swap.id,
+                  depositAddress: toAddress,
+                  depositAmount: swap.requested_amount,
+                  callData: depositAction.call_data,
+                  tokenContract: depositAction.token.contract || ''
+                });
+              } else {
+                console.error('No deposit action in swap response');
+                resolve(null);
+              }
+            } catch (e) {
+              console.error('Failed to parse swap response:', e);
+              resolve(null);
+            }
+          } else {
+            console.error(`Swap creation failed: ${res.statusCode} - ${data}`);
+            resolve(null);
+          }
+        });
+      });
+      
+      req.on('error', (error) => {
+        console.error('Request error:', error);
+        resolve(null);
+      });
+      
+      req.write(JSON.stringify(swapData));
+      req.end();
+    });
+  }
+}

--- a/src/services/realtimeTransactionMonitor.ts
+++ b/src/services/realtimeTransactionMonitor.ts
@@ -37,6 +37,7 @@ export class RealtimeTransactionMonitor {
    * Start real-time monitoring for a specific payment using WebSockets
    */
   static async startMonitoring(
+    recipientAddress: string,
     tokenAddress: string,
     expectedAmount: bigint,
     tokenSymbol: string,
@@ -53,12 +54,12 @@ export class RealtimeTransactionMonitor {
     console.log(`🔢 Expected amount: ${expectedAmount.toString()} smallest units`);
     console.log(`📊 Display amount: ${Number(expectedAmount) / Math.pow(10, tokenDecimals)} ${tokenSymbol}`);
     console.log(`⛓️  Chain: ${chainName} (ID: ${chainId})`);
-    console.log(`🏠 Recipient: ${MERCHANT_ADDRESS}`);
+    console.log(`🏠 Recipient: ${recipientAddress}`);
     console.log(`📄 Token contract: ${tokenAddress}`);
 
     // Store the monitoring session
     this.currentSession = {
-      recipientAddress: MERCHANT_ADDRESS,
+      recipientAddress,
       expectedAmount,
       tokenAddress,
       tokenSymbol,

--- a/src/services/transactionMonitoringService.ts
+++ b/src/services/transactionMonitoringService.ts
@@ -25,6 +25,7 @@ export class TransactionMonitoringService {
    * Start monitoring for a specific payment
    */
   static async startMonitoring(
+    recipientAddress: string,
     tokenAddress: string,
     expectedAmount: bigint,
     tokenSymbol: string,
@@ -41,12 +42,12 @@ export class TransactionMonitoringService {
     console.log(`🔢 Expected amount: ${expectedAmount.toString()} smallest units`);
     console.log(`📊 Display amount: ${Number(expectedAmount) / Math.pow(10, tokenDecimals)} ${tokenSymbol}`);
     console.log(`⛓️  Chain: ${chainName} (ID: ${chainId})`);
-    console.log(`🏠 Recipient: ${MERCHANT_ADDRESS}`);
+    console.log(`🏠 Recipient: ${recipientAddress}`);
     console.log(`📄 Token contract: ${tokenAddress}`);
 
     // Store the monitoring session
     this.currentSession = {
-      recipientAddress: MERCHANT_ADDRESS,
+      recipientAddress,
       expectedAmount,
       tokenAddress,
       tokenSymbol,

--- a/src/types/bridge.ts
+++ b/src/types/bridge.ts
@@ -1,0 +1,65 @@
+/**
+ * Generic interface for cross-chain bridge providers
+ */
+export interface BridgeProvider {
+  /**
+   * Name of the bridge provider (e.g., "Layerswap", "Across", etc.)
+   */
+  name: string;
+
+  /**
+   * Initialize the bridge provider
+   */
+  initialize(): Promise<void>;
+
+  /**
+   * Check if a chain is supported by the merchant
+   */
+  isMerchantSupportedChain(chainId: number): boolean;
+
+  /**
+   * Check if there's a route from source chain to any merchant chain for a token
+   */
+  checkRoute(sourceChainId: number, tokenSymbol: string): Promise<BridgeRoute | null>;
+
+  /**
+   * Create a cross-chain swap
+   */
+  createSwap(route: BridgeRoute, amount: number): Promise<BridgeSwapResult | null>;
+}
+
+/**
+ * Result of checking for a bridge route
+ */
+export interface BridgeRoute {
+  hasRoute: boolean;
+  bridgeName: string;
+  sourceChainId: number;
+  destinationChainId: number;
+  destinationNetwork: string;
+  tokenSymbol: string;
+}
+
+/**
+ * Result of creating a bridge swap
+ */
+export interface BridgeSwapResult {
+  swapId: string;
+  depositAddress: string;
+  depositAmount: number;
+  callData?: string;
+  tokenContract?: string;
+  bridgeName: string;
+}
+
+/**
+ * Payment routing result
+ */
+export interface PaymentRoute {
+  type: 'direct' | 'bridge';
+  bridge?: {
+    name: string;
+    route: BridgeRoute;
+    swapResult: BridgeSwapResult;
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -48,4 +48,7 @@ export interface MultiChainPortfolio {
   chains: ChainBalances[];
   totalValueUSD: number;
   allTokens: TokenWithPrice[];
-} 
+}
+
+// Re-export bridge types
+export * from './bridge.js'; 

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -897,9 +897,6 @@
 
         async function initiateNFCPayment(amount) {
             try {
-                // Use a default merchant address - in production, this would come from settings
-                const merchantAddress = '0xaD66946538E4B03B1910DadE713feBb8B59Cff60';
-                
                 const response = await fetch('/initiate-payment', {
                     method: 'POST',
                     headers: {


### PR DESCRIPTION
Adds support for a generic bridging mechanism where if the merchant and user are on different chains it generates a temporary bridging address where the user sends their transaction, which is then automatically bridged to the merchant. 

Currently uses LayerSwap for this bridging however is flexible to support other bridging providers in the future.